### PR TITLE
Disable migration errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cookbooks
 tmp
 spec/dummy/db/*.sqlite3
 .DS_Store
+vendor


### PR DESCRIPTION
Even if some tenants fail, migration does not have to stop the whole.
Add an option for disabling errors:
`APARTMENT_DISABLE_ALL_MIGRATE_ERROR=true`